### PR TITLE
Fix authors meta field

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "authors": [
-    "Marcel Timmerman took over in Januari 2015 and is working on it until the present day",
-    "Paweł Pabian worked on it from 2011 until January 2015"
+    "Marcel Timmerman",
+    "Paweł Pabian"
   ],
   "depends": [
     "BSON",


### PR DESCRIPTION
The field should list authors only; not elaborate free form strings.
Currently this is causing some amusing results on the modules site: https://modules.perl6.org/search?q=author%3A2015